### PR TITLE
Fix Reset packet sending

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/canndrew/tokio-utp"
 version = "0.3.0"
 
 [dependencies]
+arraydeque = "~0.4.2"
 byteorder = "1.0"
 bytes = "0.4"
 future-utils = "0.9.0"
@@ -28,6 +29,7 @@ void = "1"
 
 [dev-dependencies]
 env_logger = "0.4.2"
+hamcrest = "~0.1.5"
 
 [features]
 default = ["netsim"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,11 @@
+extern crate arraydeque;
 extern crate byteorder;
 extern crate bytes;
 extern crate future_utils;
 extern crate futures;
+#[cfg(test)]
+#[macro_use]
+extern crate hamcrest;
 extern crate mio;
 #[cfg(test)]
 #[macro_use]

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -121,41 +121,6 @@ struct Inner {
 
 type InnerCell = Arc<RwLock<Inner>>;
 
-impl Inner {
-    fn new(handle: &Handle, socket: UdpSocket, listener_set_readiness: SetReadiness) -> Inner {
-        Inner {
-            shared: Shared {
-                socket: socket,
-                ready: Ready::empty(),
-            },
-            remote: handle.remote().clone(),
-            connections: Slab::new(),
-            connection_lookup: HashMap::new(),
-            in_buf: BytesMut::with_capacity(DEFAULT_IN_BUFFER_SIZE),
-            accept_buf: VecDeque::new(),
-            listener: listener_set_readiness,
-            listener_open: true,
-            reset_packets: ArrayDeque::new(),
-            raw_data_max: DEFAULT_RAW_DATA_MAX,
-            raw_data_buffered: 0,
-            raw_receiver: None,
-            raw_channels: HashMap::new(),
-        }
-    }
-
-    fn new_shared(
-        handle: &Handle,
-        socket: UdpSocket,
-        listener_set_readiness: SetReadiness,
-    ) -> InnerCell {
-        Arc::new(RwLock::new(Inner::new(
-            handle,
-            socket,
-            listener_set_readiness,
-        )))
-    }
-}
-
 unsafe impl Send for Inner {}
 
 struct Shared {
@@ -703,6 +668,39 @@ impl Evented for UtpStream {
 */
 
 impl Inner {
+    fn new(handle: &Handle, socket: UdpSocket, listener_set_readiness: SetReadiness) -> Inner {
+        Inner {
+            shared: Shared {
+                socket: socket,
+                ready: Ready::empty(),
+            },
+            remote: handle.remote().clone(),
+            connections: Slab::new(),
+            connection_lookup: HashMap::new(),
+            in_buf: BytesMut::with_capacity(DEFAULT_IN_BUFFER_SIZE),
+            accept_buf: VecDeque::new(),
+            listener: listener_set_readiness,
+            listener_open: true,
+            reset_packets: ArrayDeque::new(),
+            raw_data_max: DEFAULT_RAW_DATA_MAX,
+            raw_data_buffered: 0,
+            raw_receiver: None,
+            raw_channels: HashMap::new(),
+        }
+    }
+
+    fn new_shared(
+        handle: &Handle,
+        socket: UdpSocket,
+        listener_set_readiness: SetReadiness,
+    ) -> InnerCell {
+        Arc::new(RwLock::new(Inner::new(
+            handle,
+            socket,
+            listener_set_readiness,
+        )))
+    }
+
     fn accept(&mut self) -> io::Result<UtpStream> {
         match self.accept_buf.pop_front() {
             Some(socket) => {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -1136,6 +1136,7 @@ impl Inner {
         Ok((bytes, addr))
     }
 
+    /// Returns true, if socket is still ready to write.
     fn flush_all(&mut self) -> io::Result<bool> {
         if self.connection_lookup.is_empty() {
             return Ok(true);
@@ -1283,6 +1284,7 @@ impl Connection {
         Ok(self.is_finalized())
     }
 
+    /// Returns true, if socket is still ready to write.
     fn flush(&mut self, shared: &mut Shared) -> io::Result<bool> {
         let mut sent = false;
 


### PR DESCRIPTION
UdpSocket::send_to() does not guarantee datagram will be sent. It might return WoudlBlock error.
Hence, we must make sure we poll send_to until it returns success.
See: https://docs.rs/tokio-core/0.1.17/src/tokio_core/net/udp/mod.rs.html#157-170