### PR TITLE
MAID-2800: fix windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ configuration:
   - Release
 
 build_script:
-  - cargo check --verbose --release --lib --tests --examples
+  - cargo check --verbose --release --lib --tests --examples --no-default-features
 
 test_script:
-  - cargo test --verbose --release
+  - cargo test --verbose --release --no-default-features


### PR DESCRIPTION
netsim is a default feature. It doesn't work on Windows. Let's disable it.